### PR TITLE
Replace ics with icalendar for Python 3.14 compatibility

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -1,12 +1,14 @@
+import datetime
 import requests as req
-from ics import Calendar, Event
+from icalendar import Calendar, Event
 
 
-def fetch_address_ids(auth_headers: dict, config: dict, streetname: str,
-                      number: int, postalcode: int) -> dict:
-    zip_resp = req.get(config["api_endpoint"] + "/zipcodes",
-                       {"q": postalcode},
-                       headers=auth_headers)
+def fetch_address_ids(
+    auth_headers: dict, config: dict, streetname: str, number: int, postalcode: int
+) -> dict:
+    zip_resp = req.get(
+        config["api_endpoint"] + "/zipcodes", {"q": postalcode}, headers=auth_headers
+    )
     if zip_resp.status_code == 200:
         zip_json = zip_resp.json()
         zip_id = ""
@@ -15,16 +17,19 @@ def fetch_address_ids(auth_headers: dict, config: dict, streetname: str,
                 zip_id = item["id"]
                 break
         if zip_id == "":
-            raise Exception("Could not find the right zip code."
-                            f"Zip code = {postalcode}")
+            raise Exception(
+                "Could not find the right zip code." f"Zip code = {postalcode}"
+            )
     else:
-        raise Exception("Error occured while fetching zipcode id. "
-                        f"[HTTP {zip_resp.status_code}]")
+        raise Exception(
+            "Error occured while fetching zipcode id. " f"[HTTP {zip_resp.status_code}]"
+        )
 
-    street_resp = req.post(config["api_endpoint"] + "/streets",
-                           params={"q": streetname,
-                                   "zipcodes": zip_id},
-                           headers=auth_headers)
+    street_resp = req.post(
+        config["api_endpoint"] + "/streets",
+        params={"q": streetname, "zipcodes": zip_id},
+        headers=auth_headers,
+    )
     if street_resp.status_code == 200:
         street_json = street_resp.json()
         street_id = ""
@@ -33,37 +38,40 @@ def fetch_address_ids(auth_headers: dict, config: dict, streetname: str,
                 street_id = item["id"]
                 break
         if street_id == "":
-            raise Exception("Could not find the right street name. "
-                            f"Street name = {streetname}")
+            raise Exception(
+                "Could not find the right street name. " f"Street name = {streetname}"
+            )
     else:
-        raise Exception("Error occured while fetching street id. "
-                        f"[HTTP {street_resp.status_code}]")
+        raise Exception(
+            "Error occured while fetching street id. "
+            f"[HTTP {street_resp.status_code}]"
+        )
 
-    return {
-        "zip": zip_id,
-        "street": street_id,
-        "housenumber": number
-    }
+    return {"zip": zip_id, "street": street_id, "housenumber": number}
 
 
-def fetch_collections(auth_headers: dict, config: dict,
-                      address_ids: dict, from_date: str, to_date: str) -> dict:
+def fetch_collections(
+    auth_headers: dict, config: dict, address_ids: dict, from_date: str, to_date: str
+) -> dict:
     req_params = {
         "zipcodeId": address_ids["zip"],
         "streetId": address_ids["street"],
         "houseNumber": address_ids["housenumber"],
         "fromDate": from_date,
         "untilDate": to_date,
-        "size": "200"
+        "size": "200",
     }
-    collection_resp = req.get(config["api_endpoint"] + "/collections",
-                              req_params, headers=auth_headers)
+    collection_resp = req.get(
+        config["api_endpoint"] + "/collections", req_params, headers=auth_headers
+    )
 
     if collection_resp.status_code == 200:
         collections = collection_resp.json()
     else:
-        raise Exception("Something went wrong while fetching collections."
-                        f"[{collection_resp.status_code}]")
+        raise Exception(
+            "Something went wrong while fetching collections."
+            f"[{collection_resp.status_code}]"
+        )
     return collections
 
 
@@ -71,26 +79,29 @@ def create_calendar(collections, lang, set_day_events) -> Calendar:
     collection_msg = {
         "nl": "Ophaling van ",
         "fr": "Collecte de ",
-        "en": "Collection of "
+        "en": "Collection of ",
     }
     calendar = Calendar()
+    calendar.add("prodid", "-//Belgian Recycle Calendar//EN")
+    calendar.add("version", "2.0")
     for item in collections["items"]:
         if item.get("exception", {}).get("replacedBy") is None:
             e = Event()
             if item["type"] == "collection":
-                e.name = collection_msg[lang] + item["fraction"]["name"][lang]
+                e.add("summary", collection_msg[lang] + item["fraction"]["name"][lang])
+                date = datetime.date.fromisoformat(item["timestamp"][:10])
                 if set_day_events:
-                    e.begin = item["timestamp"]
-                    e.make_all_day()
+                    e.add("dtstart", date)
                 else:
-                    e.begin = item["timestamp"][:10] + "T06:00:00.000"
-                    e.duration = {"minutes": 60}
+                    e.add(
+                        "dtstart", datetime.datetime.combine(date, datetime.time(6, 0))
+                    )
+                    e.add("duration", datetime.timedelta(hours=1))
             elif item["type"] == "event":
-                e.name = item["event"]["title"][lang]
-                e.description = item["event"]["description"][lang] + "\n\n"
-                e.begin = item["timestamp"]
-                e.make_all_day()
-                e.location = item["event"]["introduction"][lang]
-                e.url = item["event"]["externalLink"][lang]
-            calendar.events.add(e)
+                e.add("summary", item["event"]["title"][lang])
+                e.add("description", item["event"]["description"][lang] + "\n\n")
+                e.add("dtstart", datetime.date.fromisoformat(item["timestamp"][:10]))
+                e.add("location", item["event"]["introduction"][lang])
+                e.add("url", item["event"]["externalLink"][lang])
+            calendar.add_component(e)
     return calendar

--- a/main.py
+++ b/main.py
@@ -4,52 +4,77 @@ import os
 import click
 import datetime
 
-from lib import (create_calendar, fetch_address_ids, fetch_collections)
+from lib import create_calendar, fetch_address_ids, fetch_collections
 
 
 @click.command()
-@click.option("-s", "--streetname", type=str, required=True,
-              help="The street name for which you would like to generate the "
-              "recycle calendar", prompt="Please enter your streetname")
-@click.option("-n", "--number", type=int, required=True,
-              help="The housenumber for which you would like to generate the "
-              "recycle calendar", prompt="Please enter your housenumber "
-              "(without apt./bus suffix)")
-@click.option("-p", "--postalcode", type=int, required=True,
-              help="The postal code for which you would like to generate the "
-              "recycle calendar", prompt="Please enter your postal code")
-@click.option("-l", "--lang", type=click.Choice(['nl', 'fr', 'en'],
-              case_sensitive=False), default='en', required=False,
-              help="The preferred language of the recycle "
-              "calendar. Options are: 'nl', 'fr', and 'en'. Defaults to 'en'.",
-              prompt="Please specify your preferred language")
-def click_main(streetname, number, postalcode, lang='en', year=None):
+@click.option(
+    "-s",
+    "--streetname",
+    type=str,
+    required=True,
+    help="The street name for which you would like to generate the " "recycle calendar",
+    prompt="Please enter your streetname",
+)
+@click.option(
+    "-n",
+    "--number",
+    type=int,
+    required=True,
+    help="The housenumber for which you would like to generate the " "recycle calendar",
+    prompt="Please enter your housenumber " "(without apt./bus suffix)",
+)
+@click.option(
+    "-p",
+    "--postalcode",
+    type=int,
+    required=True,
+    help="The postal code for which you would like to generate the " "recycle calendar",
+    prompt="Please enter your postal code",
+)
+@click.option(
+    "-l",
+    "--lang",
+    type=click.Choice(["nl", "fr", "en"], case_sensitive=False),
+    default="en",
+    required=False,
+    help="The preferred language of the recycle "
+    "calendar. Options are: 'nl', 'fr', and 'en'. Defaults to 'en'.",
+    prompt="Please specify your preferred language",
+)
+def click_main(streetname, number, postalcode, lang="en", year=None):
 
     year = datetime.datetime.now().year
 
     filedir = os.path.dirname(__file__)
     # Load config
-    config = json.load(open(os.path.join(filedir, "config.json"), 'r'))
+    config = json.load(open(os.path.join(filedir, "config.json"), "r"))
     auth_headers = config["headers"]
 
     try:
         # Get address IDs
-        address_ids = fetch_address_ids(auth_headers, config, streetname,
-                                        number, postalcode)
+        address_ids = fetch_address_ids(
+            auth_headers, config, streetname, number, postalcode
+        )
     except Exception:
-        print("Something went wrong while fetching your address. Are you sure "
-              "you entered the correct address? If so, please open an issue "
-              "for this on GitHub.")
+        print(
+            "Something went wrong while fetching your address. Are you sure "
+            "you entered the correct address? If so, please open an issue "
+            "for this on GitHub."
+        )
         return
 
     try:
         # Get collections for address
-        collections = fetch_collections(auth_headers, config, address_ids,
-                                        f"{year}-01-01", f"{year}-12-31")
+        collections = fetch_collections(
+            auth_headers, config, address_ids, f"{year}-01-01", f"{year}-12-31"
+        )
     except Exception:
-        print("Something went wrong while fetching collections for your "
-              "address. Are you sure you entered the correct address?"
-              " If so, please open an issue for this on GitHub.")
+        print(
+            "Something went wrong while fetching collections for your "
+            "address. Are you sure you entered the correct address?"
+            " If so, please open an issue for this on GitHub."
+        )
         return
 
     try:
@@ -57,15 +82,17 @@ def click_main(streetname, number, postalcode, lang='en', year=None):
         set_day_events = config["set_day_events"]
         calendar = create_calendar(collections, lang, set_day_events)
     except Exception:
-        print("Something went wrong while creating the calendar. "
-              "Please open an issue for this on GitHub.")
+        print(
+            "Something went wrong while creating the calendar. "
+            "Please open an issue for this on GitHub."
+        )
         return
 
     filename = f"recycle_calendar_{streetname}_{number}.ics"
 
     print(f"Done! Writing calendar to file: {filename}")
-    with open(filename, 'w', encoding='utf-8') as my_file:
-        my_file.writelines(calendar.serialize_iter())
+    with open(filename, "wb") as my_file:
+        my_file.write(calendar.to_ical())
 
 
 click_main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 click==8.1.3
-ics==0.7.2
+icalendar>=6.0
 requests==2.28.1


### PR DESCRIPTION
ics==0.7.2 uses tatsu internally; tatsu>=5.7 removed the buffer_class parameter from ParserConfig, causing an import error on Python 3.14. Replaced with icalendar>=6.0 which is actively maintained and has no such issues.

(bigger diff due to black formatting)